### PR TITLE
Docker network

### DIFF
--- a/promise-types/docker_network/docker_network.sh
+++ b/promise-types/docker_network/docker_network.sh
@@ -1,0 +1,45 @@
+required_attributes="state"
+optional_attributes=""
+all_attributes_are_valid="no"
+
+
+LOG_PREFIX="${0##*/}"
+
+do_validate() {
+    response_result="valid"
+}
+
+do_evaluate() {
+
+    local result
+
+    # 0 does not exist, if >0 it exists
+    result=$(docker network inspect ${request_promiser} 2>/dev/null | jq '. | length')
+
+    # Default the promise is alwasys 'kept'
+    response_result="kept"
+
+
+    log debug "${LOG_PREFIX}:${request_promiser} result: ${result}"
+
+    case "${request_attribute_state}" in
+        absent)
+            if [[ ${result} -ne 0 ]]
+            then
+                result=$(docker network rm ${request_promiser})
+                response_result="repaired"
+            fi
+        ;;
+        present)
+            if [[ ${result} -eq 0 ]]
+            then
+                result=$(docker network create ${request_promiser})
+                response_result="repaired"
+            fi
+        ;;
+    esac
+
+}
+
+. "$(dirname "$0")/cfengine.sh"
+module_main "docker_network" "1.0"

--- a/promise-types/docker_network/enable.cf
+++ b/promise-types/docker_network/enable.cf
@@ -1,5 +1,5 @@
 promise agent scl_docker_network
-# @brief Define systemd promise type
+# @brief Define scl_docker_network promise type
 {
   path => "$(sys.workdir)/modules/promises/scl_docker_network.sh";
   interpreter => "/bin/bash";

--- a/promise-types/docker_network/enable.cf
+++ b/promise-types/docker_network/enable.cf
@@ -1,0 +1,6 @@
+promise agent scl_docker_network
+# @brief Define systemd promise type
+{
+  path => "$(sys.workdir)/modules/promises/scl_docker_network.sh";
+  interpreter => "/bin/bash";
+}


### PR DESCRIPTION
Added a simple promise type to create/remove docker networks, example:
```
bundle agent docker_config()
{
    scl_docker_network:
        "public"
            state => "absent";

}
```