### PR TITLE
Avoid extra processes

### DIFF
--- a/promise-types/docker_compose/docker_compose.sh
+++ b/promise-types/docker_compose/docker_compose.sh
@@ -81,7 +81,7 @@ do_evaluate() {
     fi
 
     # format has been changed since version 2.21.0
-    docker_status=$(echo ${docker_ps_output} | jq -s '.[] | if type=="array" then . else [.] end' | jq -r '.[] | .Name + ":" + .State + ":" + .Health + ":" + .Service')
+    docker_status=$(echo ${docker_ps_output} | jq --slurp --raw-output 'flatten[] | .Name + ":" + .State + ":" + .Health + ":" + .Service')
     if [[ $? -ne 0 ]]
     then
         log error "${LOG_PREFIX}:Could not parse json output of ${docker_cmd} ps"
@@ -142,10 +142,7 @@ do_evaluate() {
             local health
             local state
 
-            name=$(echo $s | awk -F: '{ print $1 }')
-            state=$(echo $s | awk -F: '{ print $2 }')
-            health=$(echo $s | awk -F: '{ print $3 }')
-            service=$(echo $s | awk -F: '{ print $4 }')
+            IFS=: read name state health service <<< "$s"
 
             if [[ ${state} != ${DOCKER_STATES[${request_attribute_state}]} ]]
             then

--- a/promise-types/docker_network/docker_network.sh
+++ b/promise-types/docker_network/docker_network.sh
@@ -18,7 +18,7 @@ do_evaluate() {
     local result
 
     # 0 does not exist, if >0 it exists
-    result=$(docker network inspect ${request_promiser} 2>/dev/null | jq '. | length')
+    result=$(docker network inspect ${request_promiser} 2>/dev/null | jq 'length')
 
     # Default the promise is alwasys 'kept'
     response_result="kept"


### PR DESCRIPTION
* docker_compose
  - Avoid spawing extra processes by using bash's field separator to split docker status
* kernel_modules
  - Check sysfs for loaded modules [1]

[1] https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-module